### PR TITLE
Small improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,22 +134,19 @@ RUN apt remove -y unzip
 # CVE-2019-20916, PRISMA-2022-0168
 RUN rm -rf /usr/lib/python3.6
 
-## Default user
-#USER <default user>:0
-USER ${USER_UID}:${USER_GID}
-
 ## Expose port(s)
 # EXPOSE <#>
 EXPOSE 8080 8443
 
-## Default startup executable. Will treat elements of 'docker run' command, or elements of "CMD" input, as parameters.
-# ENTRYPOINT ["<executable>"]
-# Specifying a docker entrypoint that can do a little extra stuff at startup.
-# Ultimately, it will end up calling "java" to run the SensorHub class.
-ENTRYPOINT [ "./launch.sh" ]
+# Pass these to entrypoint
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+ENV OSH_HOME=${OSH_HOME}
 
-## Default startup input. Will be overridden by elements of 'docker run' command.
-# CMD ["<input to be run from the working directory>"]
+# ENTRYPOINT will be called with CMD as arguments.
+COPY ./entrypoint.sh .
+ENTRYPOINT [ "./entrypoint.sh"]
+CMD [ "./launch.sh" ]
 
 ## Declare volume(s) for mount point directories
 # VOLUME [<"/first/container/directory"><, "/second/container/directory", ...]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
 # Retrieve the sources from a repo using the REPO_URL and BRANCH passed as a command line argument
 ARG REPO_URL
 ARG BRANCH
-RUN git clone -b ${BRANCH} --recursive ${REPO_URL} .
+RUN git clone --depth 1 --shallow-submodules -b ${BRANCH} --recursive ${REPO_URL} .
 
 # Run build excluding unit tests and OSGi bundle generation, the latter is not needed for this deployment setup
 RUN chmod +x ./gradlew 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ a different git clone command, which will then be ran when the tag
 changes. Alternatively, add `--no-cache` to the build command to force
 a clean build.
 
+To get started with the default osh-node-dev-template, you can run:
+
+    docker build -t osh-node-dev-template . -f Dockerfile --build-arg BRANCH=master --build-arg REPO_URL=https://github.com/opensensorhub/osh-node-dev-template.git
+
 ## Understanding Docker Commands
 
 It is highly recommended that the user be or become familiar with docker and the following commands
 
 ● To run Docker image detached exposing ports
 
-     sudo docker run -d -p443:443 [tag]
+     sudo docker run -d -p 8080:8080 -p 8443:8443 [tag]
 
 - **-p port_visible_to_world:port_exposed_docker_container**:
   Expose additional ports by including more -p switches, one for each port to be mapped
@@ -155,7 +159,7 @@ where data is typically stored in OSH, making this data accessible outside the d
 executions of the instance. The config.json can be stored in this path to persist configuration. The launch script needs
 to be updated, if doing this, so that config.json and db are correctly referenced.
 
-     docker run -d -p 443:443 -p80:80 \
+     docker run -d -p 8443:8443 -p 8080:8080 \
      -it --name [container-friendly-name] \
      --mount type=bind,source=[mount-path]/data,target=/opt/[osh-node-path]/data \
      [tag]

--- a/README.md
+++ b/README.md
@@ -92,20 +92,65 @@ It is highly recommended that the user be or become familiar with docker and the
 
 ## Executing via Docker Compose
 
-The ```docker_compose.yml``` file must be edited to the image to use from the docker repository.
+Docker compose is originally intended for creating multiple related containers, but even for a single container
+a ```docker-compose.yml``` file is a convenient way to store configuration about creating and running docker containers.
 
-    image: [DOCKER REPO URL]/[PATH]/[PROJECT]:[TAG]
+The image to be used can be specified in different ways. Edit the ```docker-compose.yml``` file to your needs. If you
+leave it unchanged, it will run a container based on the [template project
+repository](https://github.com/opensensorhub/osh-node-dev-template).
 
-- **DOCKER REPO URL**:
-  The URL of the docker repo to pull the image from
-- **PATH**:
+To run the compose file:
+
+    sudo docker compose up
+
+Add `-d` to run in the background. On older systems, you might need `docker-compose` instead of `docker compose`.
+
+### Let compose build an image
+You can have docker compose automatically build a new image, using the Dockerfile in this repository and a reference to
+an opensensorhub project repository:
+
+    osh:
+      build:
+        context: .
+        args:
+          REPO_URL: [branch]
+          BRANCH: [url]
+
+See the docs about "Building the project" above for details on how to fill in `[branch]` and `[url]`. Note that `docker
+compose up` will only build an image if none exists yet. Add `--build` to force building it again.
+
+### Let compose use a locally built image
+You can have docker compose use an image you previously built manually with e.g. `docker build` (see "Building the
+project" above). To do so, remove the `build` section from the ```docker-compose.yml``` file and add:
+
+    osh:
+      image: [image]
+
+Here, the `[image]` is whatever you passed to `docker build -t`
+
+### Let compose pull an iamge from docker hub
+You can also have docker compose use an image from a remote docker repository. To do so, remove the `build` section from the
+```docker-compose.yml``` file and add:
+
+    osh:
+      image: [repo_url]/[path]/[project]:[tag]
+
+- **repo_url**:
+  The URL of the docker repo to pull the image from (defaults to docker hub)
+- **path**:
   The path within the docker repo to the hosted project images
-- **PROJECT**:
+- **project**:
   The project or image name to pull
-- **TAG**:
-  The tag of the image to pull, such as a version identifier
+- **tag**:
+  The tag of the image to pull, such as a version identifier (defaults to latest)
 
-## Declare volume(s) for mount point directories
+### Volume(s) for mount point directories
+The default compose file declares a number of volume mounts, which are
+directories in the current directory that will be mounted inside the
+container, so you can e.g. make config chagnes or read logfiles outside
+of the container.
+
+The default ```docker-compose.yml``` file creates these directories:
 
 ● **config**: Location of config.json and logback.xml.
 
@@ -120,12 +165,8 @@ will be first in the classpath, before any other libraries included in the image
 ● **userlib**: Any additional libraries that the user may want to include in the classpath after install. These will be
 second in the classpath, before other libraries that are included in the image.
 
-The command to execute is:
+● **logs**: Log files are created here, both global and per-module (named after the modules' uuids).
 
-     docker compose -f docker_compose.yml up -d
-
-- **-d**
-  Executes the image in detached mode, so it is safe to close the terminal window
 
 ### Shutting Down via Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ to clone, build, and deploy your own nodes in a containerized environment.
 Building is as simple as running the following command replacing the placeholders in ```[]```
 with appropriate values. See the placeholders description below the build command template.
 
-    docker build -t [tag] . -f Dockerfile --build-arg BRANCH=[branch] --build-arg REPO_URL=[url]
+    docker build -t [image] . -f Dockerfile --build-arg BRANCH=[branch] --build-arg REPO_URL=[url]
 
-- **tag**: The tag to assign to the image being built
+- **image**: The image name and tag to assign to the image being built, usually of the form ```repo_url/image:tag```
+  where the ```repo_url/``` and ```:tag``` may be omitted (tag defaults to ```latest```).
 - **branch**: The branch (or tag) to check out
 - **url**: The URL of the repository to an OpenSensorHub project based
   on [OSH Node Dev Template](https://github.com/opensensorhub/osh-node-dev-template.git)
@@ -48,7 +49,7 @@ It is highly recommended that the user be or become familiar with docker and the
 
 ● To run Docker image detached exposing ports
 
-     sudo docker run -d -p 8080:8080 -p 8443:8443 [tag]
+     sudo docker run -d -p 8080:8080 -p 8443:8443 [image]
 
 - **-p port_visible_to_world:port_exposed_docker_container**:
   Expose additional ports by including more -p switches, one for each port to be mapped
@@ -79,11 +80,11 @@ It is highly recommended that the user be or become familiar with docker and the
 
 ● To build and tag an image:
 
-     sudo docker build -t <repository>:<tag> . -f <dockerfile>
+     sudo docker build -t <image> . -f <dockerfile>
 
 ● To export an image:
 
-     sudo docker save --output [filename].tar <docker_registry>/<repository>:<tag> . -f <dockerfile>
+     sudo docker save --output [filename].tar <image> . -f <dockerfile>
 
 ● To import an image:
 
@@ -141,14 +142,13 @@ group to osh:osh for the volume being mounted
      -it \
      --name [container-friendly-name] \
      --mount type=bind,source=[mount-path],target=/opt/[osh-node-path]/[target-dir] \
-     [tag]
+     [image]
 
 - **container-friendly-name**: a friendly name for the docker container
 - **mount-path**: the absolute path to the directory to be mounted as a volume
 - **osh-node-path**: the absolute path to the directory where OpenSensorHub lives within the container
 - **target-dir**: the name of the directory where the source should be mounted within the target
-- **tag**: The tag to assign to the image being built, usually of the form ```repo_url/image:tag``` where
-  the ```repo_url/``` may be omitted
+- **image**: The image to run, usually of the form ```repo_url/image:tag``` where the ```repo_url/``` may be omitted
 
 It is recommended to start the image using the following command if you want to mount a host filesystem path directory
 where data is typically stored in OSH, making this data accessible outside the docker instance and persisting across
@@ -158,14 +158,13 @@ to be updated, if doing this, so that config.json and db are correctly reference
      docker run -d -p 8443:8443 -p 8080:8080 \
      -it --name [container-friendly-name] \
      --mount type=bind,source=[mount-path]/data,target=/opt/[osh-node-path]/data \
-     [tag]
+     [image]
 
 - **container-friendly-name**: a friendly name for the docker container
 - **mount-path**: the absolute path to the directory to be mounted as a volume
 - **osh-node-path**: the absolute path to the directory where OpenSensorHub lives within the container
 - **target-dir**: in this example it has been set to data and will contain the config and recorded data
-- **tag**: The tag to assign to the image being built, usually of the form ```repo_url/image:tag``` where
-  the ```repo_url/``` may be omitted
+- **image**: The image to run, usually of the form ```repo_url/image:tag``` where the ```repo_url/``` may be omitted
 
 If using mounted volumes and the configuration file (config.json) is hosted on the mounted volume, then change the
 launch.[sh | bat] to point to the correct path for the mounted volumes. Similarly, if data is to be stored externally to

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to clone, build, and deploy your own nodes in a containerized environment.
 Building is as simple as running the following command replacing the placeholders in ```[]```
 with appropriate values. See the placeholders description below the build command template.
 
-    docker build -t [tag] . -f dockerfile --build-arg BRANCH=[branch] --build-arg REPO_URL=[url]
+    docker build -t [tag] . -f Dockerfile --build-arg BRANCH=[branch] --build-arg REPO_URL=[url]
 
 - **tag**: The tag to assign to the image being built
 - **branch**: The branch (or tag) to check out

--- a/README.md
+++ b/README.md
@@ -130,10 +130,6 @@ The command to execute is:
 
      docker compose down
 
-### Shutting Down via Docker Compose
-
-     docker compose down
-
 ## Executing or Running a Docker Container Manually
 
 ● To run docker image detached with mounted file system & name, using present working directory for filesystem source

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ deployable distribution.
 This docker template allows you to point to a specific branch and repository URL in order
 to clone, build, and deploy your own nodes in a containerized environment.
 
+## TL;DR
+
+To quickly get OSH running with the default project and settings, clone
+this repository and run:
+
+    docke compose up
+
+Then go to http://localhost:8080/sensorhub/admin and login in with
+username "admin", password "admin".
+
 ## Cloning this Repository
 
     git clone https://github.com/nickgaray/osh-docker-template.git

--- a/README.md
+++ b/README.md
@@ -23,9 +23,20 @@ with appropriate values. See the placeholders description below the build comman
     docker build -t [tag] . -f dockerfile --build-arg BRANCH=[branch] --build-arg REPO_URL=[url]
 
 - **tag**: The tag to assign to the image being built
-- **branch**: The branch to check out
+- **branch**: The branch (or tag) to check out
 - **url**: The URL of the repository to an OpenSensorHub project based
   on [OSH Node Dev Template](https://github.com/opensensorhub/osh-node-dev-template.git)
+
+Note: If possible, it is best to specify a tag instead of a branch to
+checkout. Docker caches results based on the commands executed, without
+knowing what the command will do. The Dockerfile will run a git clone
+against the given branch (or tag) during the build. If the build is done
+a second time after the remote branch was updated, docker will not
+realize this and will use the cached result instead of the latest
+version of the branch. By using tags, every new version will have
+a different git clone command, which will then be ran when the tag
+changes. Alternatively, add `--no-cache` to the build command to force
+a clean build.
 
 ## Understanding Docker Commands
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ It is highly recommended that the user be or become familiar with docker and the
 
 ## Executing via Docker Compose
 
-This option will require the directories for mounted volumes to be created and the ownership set to the osh uid and gid
-prescribed in the Dockerfile. In addition, the ```docker_compose.yml``` file must be edited to the image to use from
+The ```docker_compose.yml``` file must be edited to the image to use from
 the docker repository as well as the ports to expose where in the mapping for ports operates on the same principle as
 the **-p** command line switch discussed in the previous section.
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,9 @@ It is highly recommended that the user be or become familiar with docker and the
 
 ## Executing via Docker Compose
 
-The ```docker_compose.yml``` file must be edited to the image to use from
-the docker repository as well as the ports to expose where in the mapping for ports operates on the same principle as
-the **-p** command line switch discussed in the previous section.
+The ```docker_compose.yml``` file must be edited to the image to use from the docker repository.
 
     image: [DOCKER REPO URL]/[PATH]/[PROJECT]:[TAG]
-    ports:
-      - [EXTERNAL]:[INTERNAL]/tcp
-      - [EXTERNAL]:[INTERNAL]/tcp
 
 - **DOCKER REPO URL**:
   The URL of the docker repo to pull the image from

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,11 @@
 name: osh-node
 services:
   osh:
-    image: [DOCKER REPO URL]/[PATH]/[PROJECT]:[TAG]
+    build:
+      context: .
+      args:
+        REPO_URL: https://github.com/opensensorhub/osh-node-dev-template.git
+        BRANCH: master
     ports:
       - 8080:8080/tcp
       - 8443:8443/tcp

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# See https://stackoverflow.com/a/39398511/740048
+# and https://forum.artixlinux.org/index.php/topic,3360.0.html
+chown -R "$USER_UID":"$USER_GID" "$OSH_HOME"
+exec setpriv --reuid "$USER_UID" --regid "$USER_GID" --init-groups "$@"


### PR DESCRIPTION
This makes some small improvements. Mostly README improvements or fixes, but also:
 - Changes `docker-compose.yml` to automatically build an image the first time it is started.
 - Adds an `entrypoint.sh` script that fixes permissions, so no manual `chown` is needed anymore.
 - Lets the docker build do a shallow clone, which is more efficient.

Let me know what you think of these, and also the docs updates, since I did throw around a few things.

The "Executing or Running a Docker Container Manually" section in the README is IMHO not very good currently, since it still uses `--mount` instead of `--volume`, uses paths that are no longer really correct, does not show a full working example, and is all the way at the bottom.

I would suggest shortening that section showing mostly just a complete command, and then maybe restructuring the sections to something like:

 1. TL;DR
 2. Cloning this repository
 3. Building & running with docker-compose
 4. Testing deployment
 5. Building manually
 6. Running manually
 7. Understanding docker commands

I've rephrased some of the headings, that is part of the proposal :-)

If this looks good to you, I can add the reordering to the PR (or create new one).